### PR TITLE
Fix/save-readname-format

### DIFF
--- a/src/isotools/_transcriptome_filter.py
+++ b/src/isotools/_transcriptome_filter.py
@@ -30,11 +30,11 @@ DEFAULT_TRANSCRIPT_FILTER = {
     'FRAGMENT': 'fragments and any("novel exonic " in a or "fragment" in a for a in annotation[1])',
     'UNSPLICED': 'len(exons)==1',
     'MULTIEXON': 'len(exons)>1',
-    'SUBSTANTIAL': 'gene.coverage.sum() * .01 < gene.coverage[:,transcript_id].sum()',
-    'HIGH_COVER': 'gene.coverage.sum(0)[transcript_id] >= 7',
-    'PERMISSIVE': 'gene.coverage.sum(0)[transcript_id] >= 2 and (FSM or not (RTTS or INTERNAL_PRIMING or FRAGMENT))',
-    'BALANCED': 'gene.coverage.sum(0)[transcript_id] >= 2 and (FSM or (HIGH_COVER and not (RTTS or FRAGMENT or INTERNAL_PRIMING)))',
-    'STRICT': 'gene.coverage.sum(0)[transcript_id] >= 7 and SUBSTANTIAL and (FSM or not (RTTS or FRAGMENT or INTERNAL_PRIMING))',
+    'SUBSTANTIAL': 'gene.coverage.sum() * .01 < gene.coverage[:,trid].sum()',
+    'HIGH_COVER': 'gene.coverage.sum(0)[trid] >= 7',
+    'PERMISSIVE': 'gene.coverage.sum(0)[trid] >= 2 and (FSM or not (RTTS or INTERNAL_PRIMING or FRAGMENT))',
+    'BALANCED': 'gene.coverage.sum(0)[trid] >= 2 and (FSM or (HIGH_COVER and not (RTTS or FRAGMENT or INTERNAL_PRIMING)))',
+    'STRICT': 'gene.coverage.sum(0)[trid] >= 7 and SUBSTANTIAL and (FSM or not (RTTS or FRAGMENT or INTERNAL_PRIMING))',
     'CAGE_SUPPORT': 'sqanti_classification is not None and sqanti_classification["within_CAGE_peak"]',
     'TSS_RATIO': 'sqanti_classification is not None and sqanti_classification["ratio_TSS"] > 1.5',
     'POLYA_MOTIF': 'sqanti_classification is not None and sqanti_classification["polyA_motif_found"]',
@@ -173,7 +173,7 @@ def add_filter(self, tag, expression, context='transcript', update=False):
     if context == 'gene':
         attributes = {k for gene in self for k in gene.data.keys() if k.isidentifier()}
     else:
-        attributes = {'gene', 'transcript_id'}
+        attributes = {'gene', 'trid'}
         if context == 'transcript':
             attributes.update({k for gene in self for transcript in gene.transcripts for k in transcript.keys() if k.isidentifier()})
         elif context == 'reference':
@@ -377,9 +377,7 @@ def _filter_transcripts(gene: 'Gene', transcripts, query_fun, filter_fun, g_filt
         if maxcoverage and gene.coverage[:, i].sum() > maxcoverage:
             continue
         filter_transcript = transcript.copy()
-        if 'transcript_id' in filter_transcript:
-            filter_transcript['ref_transcript_id'] = filter_transcript.pop('transcript_id')
         query_result = query_fun is None or query_fun(
-            **g_filter_eval, **{tag: _eval_filter_fun(f, tag, gene=gene, transcript_id=i, **filter_transcript) for tag, f in filter_fun.items()})
+            **g_filter_eval, **{tag: _eval_filter_fun(f, tag, gene=gene, trid=i, **filter_transcript) for tag, f in filter_fun.items()})
         if query_result:
             yield i, transcript

--- a/src/isotools/_transcriptome_stats.py
+++ b/src/isotools/_transcriptome_stats.py
@@ -439,7 +439,7 @@ def _check_customised_groups(transcriptome: 'Transcriptome', samples=None, group
 
     if sample_idx:
         group_dict = {gn:[transcriptome.samples.index(s) for s in sample_names] for gn, sample_names in group_dict.items()}
-    
+
     return group_dict
 
 
@@ -472,9 +472,9 @@ def entropy_calculation(self: 'Transcriptome', samples=None, groups=None, min_to
                 if relative:
                     group_entropy = (group_entropy / math.log2(transcript_number)) if transcript_number > 1 else np.nan
                 gene_entropy += [transcript_number, group_entropy]
-        
+
         entropy_tab = pd.concat([entropy_tab, pd.DataFrame([gene_entropy], columns=entropy_tab.columns)], ignore_index=True)
-    
+
     # exclude rows with all empty or NA entries in entropy columns
     entropy_tab.dropna(subset=entropy_tab.columns[2:], how='all', inplace=True)
 
@@ -485,7 +485,7 @@ def str_var_calculation(self: 'Transcriptome', samples=None, groups=None, strict
     '''
     Quantify the structural variation of genes based on selected transcripts.
     Structural variation includes (and in the same order of) distinct TSS positions, exon chains, and PAS positions.
-    
+
     :param samples: A list of sample names to specify the samples to be considered. If omitted, all samples are selected.
     :param groups: Quantification done by groups of samples. A dict {group_name:[sample_name_list]} or a list of group names. If omitted, all the samples are considered as one group.
     :param strict_ec: Distance allowed between each position, except for the first/last, in two exon chains so that they can be considered as identical.
@@ -512,7 +512,7 @@ def str_var_calculation(self: 'Transcriptome', samples=None, groups=None, strict
                 # normalize to the sum of 1
                 group_var = [n / sum(ratio_triplet) for n in ratio_triplet] if sum(ratio_triplet) > 0 else [0, 0, 0]
             gene_str_var += group_var
-        
+
         str_var_tab = pd.concat([str_var_tab, pd.DataFrame([gene_str_var], columns=str_var_tab.columns)], ignore_index=True)
 
     # replace 0 with nan, and remove rows with all nan
@@ -552,7 +552,7 @@ def filter_stats(self: 'Transcriptome', tags=None, groups=None, weight_by_covera
             if not weight_by_coverage:
                 weight[weight > 0] = 1
         # relevant_filter=[filter for filter in transcript['filter'] if  consider is None or filter in consider]
-        relevant_filter = [tag for tag in tags if filterfun[tag](gene=gene, transcript_id=transcript_id, **transcript)]
+        relevant_filter = [tag for tag in tags if filterfun[tag](gene=gene, trid=transcript_id, **transcript)]
         for filter in relevant_filter:
             weights[filter] = weights.get(filter, np.zeros(weight.shape[0])) + weight[:, transcript_id]
         if not relevant_filter:

--- a/src/isotools/gene.py
+++ b/src/isotools/gene.py
@@ -775,7 +775,7 @@ class Gene(Interval):
             if max_coverage and self.coverage[:, i].sum() > max_coverage:
                 continue
             if query is None or query_fun(
-                    **{tag: f(gene=self, transcript_id=i, **transcript) for tag, f in transcript_filter_fun.items()}):
+                    **{tag: f(gene=self, trid=i, **transcript) for tag, f in transcript_filter_fun.items()}):
                 transcript_ids.append(i)
         return transcript_ids
 
@@ -793,9 +793,7 @@ class Gene(Interval):
         transcript_ids = []
         for i, transcript in enumerate(self.ref_transcripts):
             filter_transcript = transcript.copy()
-            if 'transcript_id' in filter_transcript:
-                filter_transcript['ref_transcript_id'] = filter_transcript.pop('transcript_id')
-            if query_fun(**{tag: f(gene=self, transcript_id=i, **filter_transcript) for tag, f in transcript_filter_func.items()}):
+            if query_fun(**{tag: f(gene=self, trid=i, **filter_transcript) for tag, f in transcript_filter_func.items()}):
                 transcript_ids.append(i)
         return transcript_ids
 

--- a/src/isotools/gene.py
+++ b/src/isotools/gene.py
@@ -50,8 +50,8 @@ class Transcript(TypedDict, total=False):
     clipping: dict[str, dict[str, int]]
     annotation: tuple[int, dict[str, Any]] # TODO: Switch the dict to a TypedDict, Replace novelty with Enum
     "The annotation of the transcript. The first element is the novelty class (0=FSM,1=ISM,2=NIC,3=NNC,4=Novel gene), the second a dictionary with the subcategories."
-    reads: list[str]
-    'TODO: This seems to be inconsistent. Sometimes it is a list of read names, sometimes a dict with sample names as keys and the lists as values.'
+    reads: dict[str, list[str]]
+    'sample names as keys, list of reads as values.'
     novel_splice_sites: list[int]
     TSS_unified: dict[str, dict[int, int]]
     PAS_unified: dict[str, dict[int, int]]


### PR DESCRIPTION
Revert the rename of trid to transcript_id in the filter context, to prevent name clashes when working with gtf imports.
Fix save_readnames options not working