### PR TITLE
Feature/export-end-sequences

### DIFF
--- a/src/isotools/_transcriptome_io.py
+++ b/src/isotools/_transcriptome_io.py
@@ -1198,7 +1198,8 @@ def export_end_sequences(self: Transcriptome, reference: str, output: str, crite
     of all transcripts that meet and not meet the criterium respectively.
     :param reference: Path to the reference genome in fasta format or a FastaFile handle
     :param output: Prefix for the two output files. Files will be generated as positive.fa and negative.fa
-    :param criterium: Either a boolean property of a Transcript or a function that takes a Transcript as input and returns a boolean
+    :param criterium: Either a boolean property of a Transcript or a function that takes a Transcript as input and returns a boolean.
+        The property can also be a dotted path to a nested property, e.g. 'sqanti_classification.within_CAGE_peak'.
     :param start: If True, the TSS is used as reference point, otherwise the PAS
     :param window: Tuple of bases specifying the window size around the TSS (PAS) as number of bases (upstream, downstream).
         Total window size is upstream + downstream + 1

--- a/src/isotools/_transcriptome_io.py
+++ b/src/isotools/_transcriptome_io.py
@@ -1175,14 +1175,14 @@ def import_ref_transcripts(fn, transcriptome: Transcriptome, file_format, chromo
     return genes
 
 
-def import_sqanti_classification(self: Transcriptome, path: str):
+def import_sqanti_classification(self: Transcriptome, path: str, progress_bar=True):
     """
     Import a SQANTI classification file.
     See https://github.com/ConesaLab/SQANTI3/wiki/Understanding-the-output-of-SQANTI3-QC#classifcols
     for details.
     """
     sqanti_df = pd.read_csv(path, sep='\t')
-    for _, row in tqdm(sqanti_df.iterrows(), total=len(sqanti_df)):
+    for _, row in tqdm(sqanti_df.iterrows(), total=len(sqanti_df), disable=not progress_bar):
         isoform = row['isoform']
         gene_id = '_'.join(isoform.split('_')[:-1])
         if gene_id not in self:
@@ -1190,6 +1190,40 @@ def import_sqanti_classification(self: Transcriptome, path: str):
         gene = self[gene_id]
         transcript_id = int(isoform.split('_')[-1])
         gene.add_sqanti_classification(transcript_id, row)
+
+
+def export_end_sequences(self: Transcriptome, reference: str, output: str, criterium, start = True, window = (25, 25), **kwargs):
+    '''
+    Generates two fasta files containing the reference sequences in a window around the TSS (or PAS)
+    of all transcripts that meet and not meet the criterium respectively.
+    :param reference: Path to the reference genome in fasta format or a FastaFile handle
+    :param output: Prefix for the two output files. Files will be generated as positive.fa and negative.fa
+    :param criterium: Either a boolean property of a Transcript or a function that takes a Transcript as input and returns a boolean
+    :param start: If True, the TSS is used as reference point, otherwise the PAS
+    :param window: Tuple of bases specifying the window size around the TSS (PAS) as number of bases (upstream, downstream).
+        Total window size is upstream + downstream + 1
+    :param kwargs: Additional arguments are passed to iter_transcripts()
+    '''
+    with FastaFile(reference) as ref, open(f'{output}_positive.fa', 'w') as positive, open(f'{output}_negative.fa', 'w') as negative:
+        for gene, transcript_id, transcript in self.iter_transcripts(**kwargs):
+            center = transcript['exons'][0][0] if start == (transcript['strand'] == '+') else transcript['exons'][-1][1]
+            window_here = window if transcript['strand'] == '+' else window[::-1]
+            pos = (gene.chrom, center - window_here[0], center + window_here[1] + 1)
+            seq = ref.fetch(*pos)
+
+            passes = True
+            if isinstance(criterium, str):
+                path = criterium.split('.')
+                obj = transcript
+                for attr in path:
+                    obj = obj.get(attr)
+                passes = obj
+            elif callable(criterium):
+                passes = criterium(transcript)
+
+            assert isinstance(passes, bool), f'criterium must be a boolean property or a function that returns a boolean. got {passes} ({type(passes)})'
+            out = positive if passes else negative
+            out.write(f'>{gene.id}\t{transcript_id}\t{pos[0]}:{pos[1]}-{pos[2]}\n{seq}\n')
 
 
 def collapse_immune_genes(self: Transcriptome, maxgap=300000):

--- a/src/isotools/transcriptome.py
+++ b/src/isotools/transcriptome.py
@@ -262,8 +262,9 @@ class Transcriptome:
         write_fasta,
         export_alternative_splicing,
         import_sqanti_classification,
+        export_end_sequences,
     )
-    
+
     # filtering functionality and iterators
     from ._transcriptome_filter import add_qc_metrics, add_orf_prediction, add_filter, remove_filter, iter_genes, iter_transcripts, iter_ref_transcripts
 
@@ -274,6 +275,6 @@ class Transcriptome:
     from ._transcriptome_stats import altsplice_stats, filter_stats, transcript_length_hist, transcript_coverage_hist, \
         transcripts_per_gene_hist, exons_per_transcript_hist, downstream_a_hist, direct_repeat_hist, \
         entropy_calculation, str_var_calculation
-    
+
     # protein domain annotation
     from .domains import add_hmmer_domains, add_annotation_domains


### PR DESCRIPTION
Export 51 bp sequence window around the TSS of all transcripts to two fasta files. One where the transcripts fulfill a criterium, one where they don't.

The criterium can either be a property of all transcripts with support for dotted paths (e.g. `sqanti_classification.within_CAGE_peak`) or a function that takes in a transcript and returns a boolean.
The window size can be configured. Alternatively the end sequence can also be exported.
The fasta entries hold gene_id, transcript_id and genomic position.

Ralf wanted these, so that they can be used as training data for a ML model.