### PR TITLE
DigitalSequenceBlock instead of list for hmmer

### DIFF
--- a/src/isotools/domains.py
+++ b/src/isotools/domains.py
@@ -215,7 +215,11 @@ def get_hmmer_sequences(
                 )
                 sequences.append(text_seq.digitize(aa_alphabet))
                 seq_ids.append(seqnames)
-    return sequences, seq_ids
+    sequences_block = pyhmmer.easel.DigitalSequenceBlock(
+        alphabet=sequences[0].alphabet,
+        iterable=sequences,
+    )
+    return sequences_block, seq_ids
 
 
 #  function of isoseq.Transcriptome


### PR DESCRIPTION
This PR addresses https://github.com/MatthiasLienhard/isotools/issues/12

See also: https://github.com/althonos/pyhmmer/issues/87
pyhmmer>=0.11.1 will raise TypeError with unsupported types

Re memory usage: If a list can fit in memory, a DigitalSequenceBlock should too