### PR TITLE
Fix issue 23

### DIFF
--- a/src/isotools/_utils.py
+++ b/src/isotools/_utils.py
@@ -276,7 +276,10 @@ def find_orfs(sequence, start_codons=None, stop_codons=None, ref_cds=None):
 
 
 def has_overlap(r1, r2):
-    "check the overlap of two intervals"
+    """check the overlap of two intervals
+
+    Does not distinguish between (start,end) or (end,start) order in coordinates
+    """
     # Interval objects have lengths >=2, first two elements are coordinates
     assert len(r1) >= 2, f"Should be length >=2, instead saw: {str(r1)}"
     assert len(r2) >= 2, f"Should be length >=2, instead saw: {str(r2)}"
@@ -287,7 +290,10 @@ def has_overlap(r1, r2):
 
 
 def get_overlap(r1, r2):
-    "check the overlap of two intervals"
+    """get the overlap length of two intervals
+
+    Does not distinguish between (start,end) or (end,start) order in coordinates
+    """
     # Flip coordinates if given as (end, start)
     r1_start, r1_end = (r1[0], r1[1]) if r1[0] < r1[1] else (r1[1], r1[0])
     r2_start, r2_end = (r2[0], r2[1]) if r2[0] < r2[1] else (r2[1], r2[0])

--- a/src/isotools/_utils.py
+++ b/src/isotools/_utils.py
@@ -277,14 +277,21 @@ def find_orfs(sequence, start_codons=None, stop_codons=None, ref_cds=None):
 
 def has_overlap(r1, r2):
     "check the overlap of two intervals"
-    # assuming start < end
-    return r1[1] > r2[0] and r2[1] > r1[0]
+    # Interval objects have lengths >=2, first two elements are coordinates
+    assert len(r1) >= 2, f"Should be length >=2, instead saw: {str(r1)}"
+    assert len(r2) >= 2, f"Should be length >=2, instead saw: {str(r2)}"
+    # Flip coordinates if given as (end, start)
+    r1_start, r1_end = (r1[0], r1[1]) if r1[0] < r1[1] else (r1[1], r1[0])
+    r2_start, r2_end = (r2[0], r2[1]) if r2[0] < r2[1] else (r2[1], r2[0])
+    return r1_end > r2_start and r2_end > r1_start
 
 
 def get_overlap(r1, r2):
     "check the overlap of two intervals"
-    # assuming start < end
-    return max(0, min(r1[1], r2[1]) - max(r1[0], r2[0]))
+    # Flip coordinates if given as (end, start)
+    r1_start, r1_end = (r1[0], r1[1]) if r1[0] < r1[1] else (r1[1], r1[0])
+    r2_start, r2_end = (r2[0], r2[1]) if r2[0] < r2[1] else (r2[1], r2[0])
+    return max(0, min(r1_end, r2_end) - max(r1_start, r2_start))
 
 
 def get_intersects(tr1, tr2):


### PR DESCRIPTION
Addresses issue #23 

The simplest fix was to modify the functions `has_overlap` and `get_overlap` to change coordinates to (start, end) order if they are flipped in the input. Updated the function docstrings.

I verified the output of the downstream `add_domains_to_table` function with the example in the issue above. Adding domains with hmmer currently doesn't work properly with isotools v2.0.0 and the latest pyhmmer but I used my fork (see PR #18 ) that fixes the issue.