### PR TITLE
ci: bump actions/checkout and actions/setup-python to current versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,9 +13,9 @@ jobs:
         python-version: ['3.10', '3.11', '3.12']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
## Summary
- `tests.yml` was the only workflow still on `actions/checkout@v2`/`actions/setup-python@v2` (everything else already uses v4/v5), triggering GitHub's Node 20 deprecation warning on every run.
- Bumped both to current versions (`@v4`/`@v5`).
- Checked all other workflows; nothing else is stale.
- No version bump: this only touches CI config, not the installed package.

## Test plan
- [x] CI runs successfully with the bumped action versions