### PR TITLE
Fix comment typos across the codebase

### DIFF
--- a/src/isotools/_transcriptome_io.py
+++ b/src/isotools/_transcriptome_io.py
@@ -2238,12 +2238,12 @@ def aligned_part(cigartuples, is_reverse):
                 return (start, end)
             end += cigar[1]
             start = end
-    return (start, end)  # clipping at begining or no clipping
+    return (start, end)  # clipping at beginning or no clipping
 
 
 def get_clipping(cigartuples, pos):
     if cigartuples[0][0] == 4:
-        # clipping at the begining
+        # clipping at the beginning
         return (pos, -cigartuples[0][1])
     elif cigartuples[-1][0] == 4:
         # clipping at the end - get the reference position

--- a/src/isotools/_utils.py
+++ b/src/isotools/_utils.py
@@ -132,7 +132,7 @@ def basequal_hist(bam_fn, qual_bins=None, len_bins=None, n=10000):
     return pd.DataFrame(qual, index=idx, columns=col)
 
 
-def pairwise(iterable):  # e.g. usefull for enumerating introns
+def pairwise(iterable):  # e.g. useful for enumerating introns
     "s -> (s0,s1), (s1,s2), (s2, s3), ..."
     a, b = itertools.tee(iterable)
     next(b, None)

--- a/src/isotools/plots.py
+++ b/src/isotools/plots.py
@@ -180,7 +180,7 @@ def plot_embedding(
     :param top_var: Number of alternative splicing events which are used for the embedding.
     :param min_total: Minimum total coverage over all selected samples.
     :param min_alt_fraction: Minimum fraction of reads supporting the alternative (for both groups combined).
-    :param plot_components: The dimentions to plot (E.g. the components of the PCA)
+    :param plot_components: The dimensions to plot (E.g. the components of the PCA)
     :param splice_types: Restrict the analysis on specified splicing event(s).
     :param labels: If True, sample names are printed in the plot next to the corresponding points.
     :param groups: Set a group definition (e.g. by isoseq.Transcirptome.groups()) to color the datapoints.

--- a/src/isotools/plots.py
+++ b/src/isotools/plots.py
@@ -118,7 +118,7 @@ def plot_diff_results(
                 "vs".join(str(p[0]) for p in params_alt.values()),
             )
             continue
-        # get the paramters for the beta distiribution
+        # get the parameters for the beta distribution
         ax = axs[len(plotted)]
         # ax.boxplot([mut,wt], labels=['mut','wt'])
         sns.swarmplot(

--- a/src/isotools/splice_graph.py
+++ b/src/isotools/splice_graph.py
@@ -415,7 +415,7 @@ class SegmentGraph:
         )
         # j2: index of last segment starting before exon end (i.e. last overlapping segment)
 
-        # check truncation at begining (e.g. low position)
+        # check truncation at beginning (e.g. low position)
         if (
             len(exons) > 1  # no mono exon
             and not any(


### PR DESCRIPTION
## Summary
Leftover branch rebased onto current master, plus a few more comment typos found and fixed along the way. Comment/docstring only, no behavior change, no version bump.

## Test plan
- [x] Full `pytest` suite passes (18 passed)
- [x] `flake8`/`black` clean
- [x] CI green across the full matrix